### PR TITLE
Improve GrokService error reporting

### DIFF
--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -23,7 +23,9 @@ export class GrokService {
       );
       return response.data;
     } catch (err) {
-      throw new InternalServerErrorException('Failed to fetch data from Grok');
+      console.error('GrokService error:', err);
+      const message = err instanceof Error ? err.message : 'Failed to fetch data from Grok';
+      throw new InternalServerErrorException(`Failed to fetch data from Grok: ${message}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- log the original error in GrokService
- include the underlying message in the thrown InternalServerErrorException

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fcd27eee8832489dcc189c6eff51d