### PR TITLE
Improve Grok error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ npm run start
 ```
 
 The API will be available at `http://localhost:3000` and Swagger documentation at `http://localhost:3000/api`.
+
+## Troubleshooting
+
+If you see an error similar to:
+
+```
+Failed to fetch data from Grok: getaddrinfo ENOTFOUND api.grok.com
+```
+
+ensure that the `GROK_API_URL` in your `.env` file points to a valid host and that your network can resolve it.
+This typically means either the URL is misspelled or DNS resolution is blocked on your machine.
+

--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -24,7 +24,14 @@ export class GrokService {
       return response.data;
     } catch (err) {
       console.error('GrokService error:', err);
-      const message = err instanceof Error ? err.message : 'Failed to fetch data from Grok';
+      let message = 'Failed to fetch data from Grok';
+      if (err instanceof Error) {
+        message = err.message;
+        if ('code' in err && (err as any).code === 'ENOTFOUND') {
+          message =
+            'Unable to resolve host for GROK_API_URL. Verify the URL and your network connectivity.';
+        }
+      }
       throw new InternalServerErrorException(`Failed to fetch data from Grok: ${message}`);
     }
   }


### PR DESCRIPTION
## Summary
- handle DNS failures in `GrokService` to provide clearer message when `ENOTFOUND` occurs
- document troubleshooting steps in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd08ab1908324acddb5e49677cfab