### PR TITLE
Fix Grok API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The API will be available at `http://localhost:3000` and Swagger documentation a
 If you see an error similar to:
 
 ```
-Failed to fetch data from Grok: getaddrinfo ENOTFOUND api.grok.com
+Failed to fetch data from Grok: getaddrinfo ENOTFOUND api.grok.ai
 ```
 
-ensure that the `GROK_API_URL` in your `.env` file points to a valid host and that your network can resolve it.
+Ensure that the `GROK_API_URL` in your `.env` file points to a valid host (for example `https://api.grok.ai/v1/query`) and that your network can resolve it.
 This typically means either the URL is misspelled or DNS resolution is blocked on your machine.
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,5 @@
 GROK_API_KEY=
-GROK_API_URL=https://api.grok.com/v1/query
+# Base URL for the Grok API
+# The default value points to the public Grok API endpoint.
+GROK_API_URL=https://api.grok.ai/v1/query
 PORT=3000

--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 export class GrokService {
   async fetchNews(prompt: string) {
     const apiKey = process.env.GROK_API_KEY;
-    const url = process.env.GROK_API_URL ?? 'https://api.grok.com/v1/query';
+    const url = process.env.GROK_API_URL ?? 'https://api.grok.ai/v1/query';
     if (!apiKey) {
       throw new InternalServerErrorException('GROK_API_KEY not configured');
     }


### PR DESCRIPTION
## Summary
- correct the default Grok API URL
- update README troubleshooting instructions
- update example environment config

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd49243b88324ad0af624b67153ee