### PR TITLE
Fix TLS SNI error when calling Grok API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ Failed to fetch data from Grok: getaddrinfo ENOTFOUND api.grok.ai
 Ensure that the `GROK_API_URL` in your `.env` file points to a valid host (for example `https://api.grok.ai/v1/query`) and that your network can resolve it.
 This typically means either the URL is misspelled or DNS resolution is blocked on your machine.
 
+If you encounter an error like:
+```
+AxiosError: write EPROTO ... tlsv1 unrecognized name
+```
+ensure that your system can establish a TLS connection to the Grok API. By default the
+service will connect using a server name of `grok.ai` which avoids issues with
+some TLS proxies that reject `api.grok.ai`.

--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -12,7 +12,9 @@ export class GrokService {
     }
 
     try {
-      const httpsAgent = new https.Agent({ servername: new URL(url).hostname });
+      const host = new URL(url).hostname;
+      const servername = host === 'api.grok.ai' ? 'grok.ai' : host;
+      const httpsAgent = new https.Agent({ servername });
       const response = await axios.post(
         url,
         { prompt },


### PR DESCRIPTION
## Summary
- adjust HTTPS agent servername to use `grok.ai` for the Grok API
- document troubleshooting for TLS `unrecognized name`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687ff9d3e05c832496cab9ab24537a86