### PR TITLE
Implement lander endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ npm run start
 
 The API will be available at `http://localhost:3000` and Swagger documentation at `http://localhost:3000/api`.
 
+## Endpoints
+
+- `GET /news` returns recent viral news from Mexico.
+- `GET /lander?prompt=your+prompt` queries the Grok API with a custom prompt.
+
 ## Troubleshooting
 
 If you see an error similar to:

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -3,10 +3,11 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { GrokService } from './grok.service';
 import { NewsController } from './news.controller';
+import { LanderController } from './lander.controller';
 
 @Module({
   imports: [],
-  controllers: [AppController, NewsController],
+  controllers: [AppController, NewsController, LanderController],
   providers: [AppService, GrokService],
 })
 export class AppModule {}

--- a/server/src/lander.controller.ts
+++ b/server/src/lander.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Query, BadRequestException } from '@nestjs/common';
+import { GrokService } from './grok.service';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('lander')
+@Controller('lander')
+export class LanderController {
+  constructor(private readonly grokService: GrokService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Query Grok with a custom prompt' })
+  async lander(@Query('prompt') prompt?: string) {
+    if (!prompt) {
+      throw new BadRequestException('prompt query parameter is required');
+    }
+    return this.grokService.fetchNews(prompt);
+  }
+}


### PR DESCRIPTION
## Summary
- allow custom prompts via new `/lander` endpoint
- document API routes in README

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe return errors)*

------
https://chatgpt.com/codex/tasks/task_b_688003a220b883248a7f81f043a05cf1