### PR TITLE
Improve Grok error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The API will be available at `http://localhost:3000` and Swagger documentation a
 
 ## Endpoints
 
-- `GET /news` returns recent viral news from Mexico.
+- `GET /news` returns recent viral news from Mexico using a built-in prompt.
 - `GET /lander?prompt=your+prompt` queries the Grok API with a custom prompt.
 
 ## Troubleshooting
@@ -39,6 +39,8 @@ Failed to fetch data from Grok: getaddrinfo ENOTFOUND api.grok.ai
 
 Ensure that the `GROK_API_URL` in your `.env` file points to a valid host (for example `https://api.grok.ai/v1/query`) and that your network can resolve it.
 This typically means either the URL is misspelled or DNS resolution is blocked on your machine.
+
+The server now logs any HTTP status and response body received from Grok, which helps identify configuration issues.
 
 If you encounter an error like:
 ```

--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -26,14 +26,33 @@ export class GrokService {
     } catch (err) {
       console.error('GrokService error:', err);
       let message = 'Failed to fetch data from Grok';
-      if (err instanceof Error) {
+      if (axios.isAxiosError(err)) {
+        if (err.response) {
+          const status = err.response.status;
+          const statusText = err.response.statusText ?? 'Unknown status';
+          message = `Grok API responded with ${status}: ${statusText}`;
+          if (err.response.data) {
+            const details =
+              typeof err.response.data === 'string'
+                ? err.response.data
+                : JSON.stringify(err.response.data);
+            message += ` - ${details}`;
+          }
+        } else if (err.request) {
+          message = 'No response received from Grok';
+        } else if (err.message) {
+          message = err.message;
+        }
+      } else if (err instanceof Error) {
         message = err.message;
         if ('code' in err && (err as any).code === 'ENOTFOUND') {
           message =
             'Unable to resolve host for GROK_API_URL. Verify the URL and your network connectivity.';
         }
       }
-      throw new InternalServerErrorException(`Failed to fetch data from Grok: ${message}`);
+      throw new InternalServerErrorException(
+        `Failed to fetch data from Grok: ${message}`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary
- hardcode the prompt for `/news`
- log detailed response data when Grok queries fail
- clarify usage of `/news` in README and mention improved logs

## Testing
- `npm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_b_688285c7340483248b57d238440f1aa7