### PR TITLE
Add NestJS Grok hello world example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NewsProvider
 
-This project contains a simple NestJS backend service for fetching viral news from Mexico using the Grok API.
+This project contains a simple NestJS backend that demonstrates how to make a **Hello World** request to the Grok API.
 
 ## Setup
 
@@ -22,12 +22,11 @@ cp .env.example .env
 npm run start
 ```
 
-The API will be available at `http://localhost:3000` and Swagger documentation at `http://localhost:3000/api`.
+The API will be available at `http://localhost:3000` with Swagger documentation at `http://localhost:3000/api`.
 
-## Endpoints
+## Endpoint
 
-- `GET /news` returns recent viral news from Mexico using a built-in prompt.
-- `GET /lander?prompt=your+prompt` queries the Grok API with a custom prompt.
+- `GET /hello` queries the Grok API with the prompt "hello world" and returns the response.
 
 ## Troubleshooting
 
@@ -38,14 +37,11 @@ Failed to fetch data from Grok: getaddrinfo ENOTFOUND api.grok.ai
 ```
 
 Ensure that the `GROK_API_URL` in your `.env` file points to a valid host (for example `https://api.grok.ai/v1/query`) and that your network can resolve it.
-This typically means either the URL is misspelled or DNS resolution is blocked on your machine.
 
-The server now logs any HTTP status and response body received from Grok, which helps identify configuration issues.
+The server logs any HTTP status and response body received from Grok, which helps identify configuration issues.
 
 If you encounter an error like:
 ```
 AxiosError: write EPROTO ... tlsv1 unrecognized name
 ```
-ensure that your system can establish a TLS connection to the Grok API. By default the
-service will connect using a server name of `grok.ai` which avoids issues with
-some TLS proxies that reject `api.grok.ai`.
+ensure that your system can establish a TLS connection to the Grok API. By default the service will connect using a server name of `grok.ai` which avoids issues with some TLS proxies that reject `api.grok.ai`.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,4 @@
+GROK_API_KEY=
+# Base URL for the Grok API
+GROK_API_URL=https://api.grok.ai/v1/query
+PORT=3000

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "server",
+  "version": "0.0.1",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "start:dev": "ts-node-dev --respawn src/main.ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^11.0.1",
+    "@nestjs/core": "^11.0.1",
+    "@nestjs/platform-express": "^11.0.1",
+    "axios": "^1.10.0",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1",
+    "@nestjs/swagger": "^11.2.0",
+    "swagger-ui-express": "^5.0.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.7.3",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { GrokController } from './grok.controller';
+import { GrokService } from './grok.service';
+
+@Module({
+  imports: [],
+  controllers: [GrokController],
+  providers: [GrokService],
+})
+export class AppModule {}

--- a/server/src/grok.controller.ts
+++ b/server/src/grok.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { GrokService } from './grok.service';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+
+@ApiTags('grok')
+@Controller('hello')
+export class GrokController {
+  constructor(private readonly grokService: GrokService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Return hello world from Grok' })
+  async getHello() {
+    return this.grokService.helloWorld();
+  }
+}

--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import axios from 'axios';
+import * as https from 'node:https';
+
+@Injectable()
+export class GrokService {
+  async helloWorld() {
+    const apiKey = process.env.GROK_API_KEY;
+    const url = process.env.GROK_API_URL ?? 'https://api.grok.ai/v1/query';
+    if (!apiKey) {
+      throw new InternalServerErrorException('GROK_API_KEY not configured');
+    }
+    try {
+      const host = new URL(url).hostname;
+      const servername = host === 'api.grok.ai' ? 'grok.ai' : host;
+      const httpsAgent = new https.Agent({ servername });
+      const response = await axios.get(url, {
+        params: { prompt: 'hello world' },
+        headers: { Authorization: `Bearer ${apiKey}` },
+        httpsAgent,
+      });
+      return response.data;
+    } catch (err) {
+      console.error('Failed to fetch data from Grok:', err);
+      throw new InternalServerErrorException('Failed to fetch data from Grok');
+    }
+  }
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,0 +1,20 @@
+import { NestFactory } from '@nestjs/core';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const config = new DocumentBuilder()
+    .setTitle('Grok Hello World')
+    .setDescription('Simple example using Grok API')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+  await app.listen(process.env.PORT ?? 3000);
+}
+
+bootstrap().catch((err) => {
+  console.error('Failed to start application', err);
+  process.exit(1);
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- reintroduce a minimal `server` directory with a NestJS project
- show how to hit Grok using a Hello World prompt
- document setup and new `/hello` endpoint in `README.md`

## Testing
- `npm install`
- `npm run start` (manual run)

------
https://chatgpt.com/codex/tasks/task_b_68828f5a74d08324b30fa2c21e5bbf60