### PR TITLE
Disable ts-node cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ cp .env.example .env
 npm run start
 ```
 
+The command disables ts-node's cache so the code is always compiled from scratch.
 The API will be available at `http://localhost:3000` with Swagger documentation at `http://localhost:3000/api`.
 
 ## Endpoint

--- a/server/package.json
+++ b/server/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "start": "ts-node src/main.ts",
-    "start:dev": "ts-node-dev --respawn src/main.ts"
+    "start": "TS_NODE_CACHE=false ts-node src/main.ts",
+    "start:dev": "TS_NODE_CACHE=false ts-node-dev --respawn --no-cache src/main.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",


### PR DESCRIPTION
## Summary
- disable ts-node cache in the start scripts so builds never use old cache
- document that the server runs with cache disabled

## Testing
- `npx ts-node-dev --help` *(fails: npm error because ts-node-dev not installed)*

------
https://chatgpt.com/codex/tasks/task_b_688299bb13e083249dc45da6b5bc37da