### PR TITLE
Fix Grok endpoint returning HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ The API will be available at `http://localhost:3000` with Swagger documentation 
 
 ## Endpoint
 
-- `GET /hello` queries the Grok API with the prompt "hello world" and returns the response.
+- `GET /hello` queries the Grok API with the prompt "hello world" and returns the
+  response. The server now sends a POST request to the Grok API to avoid HTML
+  responses that redirect to `/lander`.
 
 ## Troubleshooting
 

--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -14,11 +14,17 @@ export class GrokService {
       const host = new URL(url).hostname;
       const servername = host === 'api.grok.ai' ? 'grok.ai' : host;
       const httpsAgent = new https.Agent({ servername });
-      const response = await axios.get(url, {
-        params: { prompt: 'hello world' },
-        headers: { Authorization: `Bearer ${apiKey}` },
-        httpsAgent,
-      });
+      const response = await axios.post(
+        url,
+        { prompt: 'hello world' },
+        {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            Accept: 'application/json',
+          },
+          httpsAgent,
+        },
+      );
       return response.data;
     } catch (err) {
       console.error('Failed to fetch data from Grok:', err);


### PR DESCRIPTION
## Summary
- switch Grok service call from `GET` to `POST`
- document POST request in README

## Testing
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_b_6882a5fd8c18832497e222c148c1bf22