### PR TITLE
Add news endpoint using Grok completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+server/node_modules/
+server/package-lock.json
+server/.env

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Copy `.env.example` to `.env` and provide the `GROK_API_KEY`.
 ```bash
 cp .env.example .env
 # edit .env and set GROK_API_KEY
+# optionally set GROK_COMPLETION_URL if you need to override the default
 ```
 
 ## Running the server
@@ -30,6 +31,8 @@ The API will be available at `http://localhost:3000` with Swagger documentation 
 - `GET /hello` queries the Grok API with the prompt "hello world" and returns the
   response. The server now sends a POST request to the Grok API to avoid HTML
   responses that redirect to `/lander`.
+- `GET /news` returns a JSON payload with trending news articles by calling the
+  Grok chat completions API.
 
 ## Troubleshooting
 
@@ -40,6 +43,7 @@ Failed to fetch data from Grok: getaddrinfo ENOTFOUND api.grok.ai
 ```
 
 Ensure that the `GROK_API_URL` in your `.env` file points to a valid host (for example `https://api.grok.ai/v1/query`) and that your network can resolve it.
+If you use the news endpoint, also verify `GROK_COMPLETION_URL` points to a reachable host.
 
 The server logs any HTTP status and response body received from Grok, which helps identify configuration issues.
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,6 @@
 GROK_API_KEY=
 # Base URL for the Grok API
 GROK_API_URL=https://api.grok.ai/v1/query
+# Endpoint for the Grok chat completions API
+GROK_COMPLETION_URL=https://api.x.ai/v1/chat/completions
 PORT=3000

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { GrokController } from './grok.controller';
 import { GrokService } from './grok.service';
+import { NewsController } from './news.controller';
 
 @Module({
   imports: [],
-  controllers: [GrokController],
+  controllers: [GrokController, NewsController],
   providers: [GrokService],
 })
 export class AppModule {}

--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -31,4 +31,53 @@ export class GrokService {
       throw new InternalServerErrorException('Failed to fetch data from Grok');
     }
   }
+
+  async trendingNews() {
+    const apiKey = process.env.GROK_API_KEY;
+    const url =
+      process.env.GROK_COMPLETION_URL ??
+      'https://api.x.ai/v1/chat/completions';
+    if (!apiKey) {
+      throw new InternalServerErrorException('GROK_API_KEY not configured');
+    }
+    try {
+      const host = new URL(url).hostname;
+      const servername = host.startsWith('api.') ? host.slice(4) : host;
+      const httpsAgent = new https.Agent({ servername });
+      const response = await axios.post(
+        url,
+        {
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a news reporter.',
+            },
+            {
+              role: 'user',
+              content:
+                'Return a JSON object with a single key articles which is an array of 10 viral news articles for the locale es-MX. The news must be from the last 3 days. Each article object must have the following keys: title, summary, source, date, referenceUrl, and imageHint. Based on recent viral news or trending news right now on X and other media.',
+            },
+          ],
+          model: 'grok-4',
+          stream: false,
+          search_parameters: { mode: 'on' },
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          httpsAgent,
+          timeout: 3600_000,
+        },
+      );
+      return response.data;
+    } catch (err) {
+      console.error('Failed to fetch trending news from Grok:', err);
+      throw new InternalServerErrorException(
+        'Failed to fetch trending news from Grok',
+      );
+    }
+  }
 }

--- a/server/src/news.controller.ts
+++ b/server/src/news.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { GrokService } from './grok.service';
+
+@ApiTags('news')
+@Controller('news')
+export class NewsController {
+  constructor(private readonly grokService: GrokService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Return trending news articles from Grok' })
+  async getNews() {
+    return this.grokService.trendingNews();
+  }
+}


### PR DESCRIPTION
## Summary
- ignore node_modules and env files
- add GROK_COMPLETION_URL variable
- add NewsController and service method `trendingNews`
- expose `/news` endpoint in `AppModule`
- document new endpoint in README

## Testing
- `npm run start`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6882d2be8c5c8324b9e363543ecc1d79