### PR TITLE
Add cron-friendly news caching with Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Copy `.env.example` to `.env` and provide the `GROK_API_KEY`.
 cp .env.example .env
 # edit .env and set GROK_API_KEY
 # optionally set GROK_COMPLETION_URL if you need to override the default
+# optionally set REDIS_URL if your Redis instance is not running locally
 ```
 
 ## Running the server
@@ -26,13 +27,24 @@ npm run start
 The command disables ts-node's cache so the code is always compiled from scratch.
 The API will be available at `http://localhost:3000` with Swagger documentation at `http://localhost:3000/api`.
 
+## Fetching news
+
+Run the following command to fetch trending news and cache it in Redis:
+
+```bash
+npm run fetch-news
+```
+
+You can schedule this command using cron to keep the cached news up to date.
+
 ## Endpoint
 
 - `GET /hello` queries the Grok API with the prompt "hello world" and returns the
   response. The server now sends a POST request to the Grok API to avoid HTML
   responses that redirect to `/lander`.
-- `GET /news` returns a JSON payload with trending news articles by calling the
-  Grok chat completions API.
+- `GET /news` returns a JSON payload with trending news articles stored in Redis.
+  The data is populated by running the `npm run fetch-news` script, which can be
+  scheduled with cron.
 
 ## Troubleshooting
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,3 +4,4 @@ GROK_API_URL=https://api.grok.ai/v1/query
 # Endpoint for the Grok chat completions API
 GROK_COMPLETION_URL=https://api.x.ai/v1/chat/completions
 PORT=3000
+REDIS_URL=redis://localhost:6379

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "license": "UNLICENSED",
   "scripts": {
     "start": "TS_NODE_CACHE=false ts-node src/main.ts",
-    "start:dev": "TS_NODE_CACHE=false ts-node-dev --respawn --no-cache src/main.ts"
+    "start:dev": "TS_NODE_CACHE=false ts-node-dev --respawn --no-cache src/main.ts",
+    "fetch-news": "TS_NODE_CACHE=false ts-node src/fetch-news.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
@@ -15,7 +16,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "@nestjs/swagger": "^11.2.0",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "redis": "^5.6.1"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/server/src/fetch-news.ts
+++ b/server/src/fetch-news.ts
@@ -1,0 +1,15 @@
+import { GrokService } from './grok.service';
+import { getRedisClient } from './redis-client';
+
+async function main() {
+  const service = new GrokService();
+  const news = await service.fetchTrendingNewsFromApi();
+  const client = await getRedisClient();
+  await client.set('news:latest', JSON.stringify(news));
+  await client.quit();
+}
+
+main().catch((err) => {
+  console.error('Failed to fetch and store news', err);
+  process.exit(1);
+});

--- a/server/src/redis-client.ts
+++ b/server/src/redis-client.ts
@@ -1,0 +1,13 @@
+import { createClient, RedisClientType } from 'redis';
+
+let client: RedisClientType | null = null;
+
+export async function getRedisClient(): Promise<RedisClientType> {
+  if (!client) {
+    const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
+    client = createClient({ url });
+    client.on('error', (err) => console.error('Redis error', err));
+    await client.connect();
+  }
+  return client;
+}


### PR DESCRIPTION
## Summary
- store trending news in Redis and fetch it with a new cron-friendly script
- read cached news from Redis instead of calling the API
- expose `REDIS_URL` in `.env.example`
- document how to fetch news and update `/news` endpoint docs

## Testing
- `npm install`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_6882df3308a48324a777bbd96ee3acc4