### PR TITLE
Increase fetch-news timeout

### DIFF
--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -104,8 +104,8 @@ export class GrokService {
           Accept: 'application/json',
         },
         httpsAgent,
-        // Allow up to 3 minutes for the request to complete
-        timeout: 180_000,
+        // Allow up to 5 minutes for the request to complete
+        timeout: 300_000,
       };
 
       logHttpRequest('POST', url, data, config);


### PR DESCRIPTION
## Summary
- extend allowed request time from 3 minutes to 5 minutes when fetching trending news

## Testing
- `npm install`
- `npx tsc -p server/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68842482dd00832497f07aaf628ea766