### PR TITLE
Update trending news API call

### DIFF
--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -77,9 +77,6 @@ export class GrokService {
       throw new InternalServerErrorException('GROK_API_KEY not configured');
     }
     try {
-      const host = new URL(url).hostname;
-      const servername = host.startsWith('api.') ? host.slice(4) : host;
-      const httpsAgent = new https.Agent({ servername });
       const data = {
         messages: [
           {
@@ -98,19 +95,21 @@ export class GrokService {
       };
 
       const config: AxiosRequestConfig = {
+        url,
+        method: 'POST',
         headers: {
           Authorization: `Bearer ${apiKey}`,
           'Content-Type': 'application/json',
           Accept: 'application/json',
         },
-        httpsAgent,
+        data,
         // Allow up to 5 minutes for the request to complete
         timeout: 300_000,
       };
 
       logHttpRequest('POST', url, data, config);
 
-      const response = await axios.post(url, data, config);
+      const response = await axios(config);
       return response.data;
     } catch (err) {
       console.error('Failed to fetch trending news from Grok:', err);


### PR DESCRIPTION
## Summary
- simplify `fetchTrendingNewsFromApi`
- send requests via Axios config using an explicit `url` instead of customizing the HTTPS agent

## Testing
- `npm run fetch-news` *(fails: GROK_API_KEY not configured)*

------
https://chatgpt.com/codex/tasks/task_b_6884288e1c10832481bc3f09a03a4fb9