### PR TITLE
Add custom prompt endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Copy `.env.example` to `.env` and provide the `GROK_API_KEY`.
 
 ```bash
 cp .env.example .env
-# edit .env and set GROK_API_KEY
+# edit .env and set GROK_API_KEY and API_KEY
 # optionally set GROK_COMPLETION_URL if you need to override the default
 # optionally set REDIS_URL if your Redis instance is not running locally
 # optionally set SSL_KEY_PATH and SSL_CERT_PATH to enable HTTPS
@@ -43,6 +43,8 @@ You can schedule this command using cron to keep the cached news up to date.
 - `GET /news` returns a JSON payload with trending news articles stored in Redis.
   The data is populated by running the `npm run fetch-news` script, which can be
   scheduled with cron.
+- `POST /prompt` queries Grok using a custom prompt. The request body must have a
+  `prompt` field. Provide your API key via the `X-API-Key` header.
 
 ## Troubleshooting
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,6 +5,8 @@ GROK_API_URL=https://api.grok.ai/v1/query
 GROK_COMPLETION_URL=https://api.x.ai/v1/chat/completions
 PORT=3000
 REDIS_URL=redis://localhost:6379
+# API key required for the /prompt endpoint
+API_KEY=
 # Paths to SSL key and certificate for HTTPS
 SSL_KEY_PATH=
 SSL_CERT_PATH=

--- a/server/src/api-key.guard.ts
+++ b/server/src/api-key.guard.ts
@@ -1,0 +1,17 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    const expected = process.env.API_KEY;
+    if (!expected) {
+      throw new UnauthorizedException('API_KEY not configured');
+    }
+    const provided = req.headers['x-api-key'];
+    if (!provided || provided !== expected) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+    return true;
+  }
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { GrokService } from './grok.service';
 import { NewsController } from './news.controller';
+import { PromptController } from './prompt.controller';
+import { ApiKeyGuard } from './api-key.guard';
 
 @Module({
   imports: [],
-  controllers: [NewsController],
-  providers: [GrokService],
+  controllers: [NewsController, PromptController],
+  providers: [GrokService, ApiKeyGuard],
 })
 export class AppModule {}

--- a/server/src/prompt.controller.ts
+++ b/server/src/prompt.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Post, UseGuards, BadRequestException } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { GrokService } from './grok.service';
+import { ApiKeyGuard } from './api-key.guard';
+
+@ApiTags('prompt')
+@Controller('prompt')
+export class PromptController {
+  constructor(private readonly grokService: GrokService) {}
+
+  @Post()
+  @UseGuards(ApiKeyGuard)
+  @ApiOperation({ summary: 'Query Grok with a custom prompt' })
+  async handlePrompt(@Body('prompt') prompt?: string) {
+    if (!prompt) {
+      throw new BadRequestException('Prompt is required');
+    }
+    return this.grokService.queryPrompt(prompt);
+  }
+}


### PR DESCRIPTION
## Summary
- add environment variable `API_KEY`
- implement `ApiKeyGuard` for API key validation
- create `PromptController` under `/prompt`
- expose new controller and guard via `AppModule`
- implement `queryPrompt` service method
- document new endpoint and API key setup

## Testing
- `npm install`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688a9e6d630c8324ad8fc84c5bcacbdc