### PR TITLE
Allow custom system role for /prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ You can schedule this command using cron to keep the cached news up to date.
   The data is populated by running the `npm run fetch-news` script, which can be
   scheduled with cron.
 - `POST /prompt` queries Grok using a custom prompt. The request body must have a
-  `prompt` field. Provide your API key via the `X-API-Key` header.
+  `prompt` field and may optionally include `system_role` to override the default
+  system prompt. Provide your API key via the `X-API-Key` header.
 
 ## Troubleshooting
 

--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -91,7 +91,7 @@ export class GrokService {
     }
   }
 
-  async queryPrompt(prompt: string) {
+  async queryPrompt(prompt: string, systemRole?: string) {
     const apiKey = process.env.GROK_API_KEY;
     const url =
       process.env.GROK_COMPLETION_URL ??
@@ -104,7 +104,9 @@ export class GrokService {
         messages: [
           {
             role: 'system',
-            content: 'You are a news reporter.',
+            content: systemRole && systemRole.trim().length > 0
+              ? systemRole
+              : 'You are a news reporter.',
           },
           {
             role: 'user',

--- a/server/src/prompt.controller.ts
+++ b/server/src/prompt.controller.ts
@@ -11,10 +11,13 @@ export class PromptController {
   @Post()
   @UseGuards(ApiKeyGuard)
   @ApiOperation({ summary: 'Query Grok with a custom prompt' })
-  async handlePrompt(@Body('prompt') prompt?: string) {
+  async handlePrompt(
+    @Body('prompt') prompt?: string,
+    @Body('system_role') systemRole?: string,
+  ) {
     if (!prompt) {
       throw new BadRequestException('Prompt is required');
     }
-    return this.grokService.queryPrompt(prompt);
+    return this.grokService.queryPrompt(prompt, systemRole);
   }
 }


### PR DESCRIPTION
## Summary
- add optional `system_role` parameter for `/prompt` endpoint
- handle `system_role` in service when querying Grok
- document the optional parameter in README

## Testing
- `npm install`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_688aa27a10688324859b0ec79d3bddb4