### PR TITLE
Add logging for Grok API responses

### DIFF
--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -24,6 +24,22 @@ function logHttpRequest(
   console.debug(lines.join('\n'));
 }
 
+function logHttpResponse(
+  method: string,
+  url: string,
+  status: number,
+  data: any,
+) {
+  const lines: string[] = [
+    `${method.toUpperCase()} ${url} -> ${status}`,
+  ];
+  lines.push('');
+  if (data) {
+    lines.push(typeof data === 'string' ? data : JSON.stringify(data, null, 2));
+  }
+  console.debug(lines.join('\n'));
+}
+
 @Injectable()
 export class GrokService {
 
@@ -82,6 +98,7 @@ export class GrokService {
       logHttpRequest('POST', url, data, config);
 
       const response = await axios(config);
+      logHttpResponse('POST', url, response.status, response.data);
       return response.data;
     } catch (err) {
       console.error('Failed to fetch trending news from Grok:', err);
@@ -133,6 +150,7 @@ export class GrokService {
       logHttpRequest('POST', url, data, config);
 
       const response = await axios(config);
+      logHttpResponse('POST', url, response.status, response.data);
       return response.data;
     } catch (err) {
       console.error('Failed to query Grok:', err);

--- a/server/src/news.controller.ts
+++ b/server/src/news.controller.ts
@@ -10,6 +10,8 @@ export class NewsController {
   @Get()
   @ApiOperation({ summary: 'Return trending news articles from Grok' })
   async getNews() {
-    return this.grokService.trendingNews();
+    const result = await this.grokService.trendingNews();
+    console.debug('Sending trending news response');
+    return result;
   }
 }

--- a/server/src/prompt.controller.ts
+++ b/server/src/prompt.controller.ts
@@ -18,6 +18,8 @@ export class PromptController {
     if (!prompt) {
       throw new BadRequestException('Prompt is required');
     }
-    return this.grokService.queryPrompt(prompt, systemRole);
+    const result = await this.grokService.queryPrompt(prompt, systemRole);
+    console.debug('Sending prompt response');
+    return result;
   }
 }


### PR DESCRIPTION
## Summary
- log outgoing Grok responses with new `logHttpResponse`
- output a message from controllers when returning data

## Testing
- `npm install`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_688aac35d6f88324a1f5360762e00463