### PR TITLE
Add file-based logger

### DIFF
--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const logFilePath = path.join(__dirname, '..', 'server.log');
+
+function write(message: string) {
+  const timestamp = new Date().toISOString();
+  fs.appendFileSync(logFilePath, `[${timestamp}] ${message}\n`);
+}
+
+export function logRequest(method: string, url: string, body: any) {
+  write(`Request ${method.toUpperCase()} ${url}\n${JSON.stringify(body, null, 2)}`);
+}
+
+export function logResponse(
+  method: string,
+  url: string,
+  body: any,
+  durationMs: number,
+) {
+  write(
+    `Response ${method.toUpperCase()} ${url} (${durationMs}ms)\n${JSON.stringify(
+      body,
+      null,
+      2,
+    )}`,
+  );
+}
+
+export function logError(err: unknown) {
+  if (err instanceof Error) {
+    write(`Error: ${err.message}\n${err.stack ?? ''}`);
+  } else {
+    write(`Error: ${JSON.stringify(err)}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add a tiny logger that writes to `server.log`
- use the logger inside `GrokService` to track requests, responses, durations and errors

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_b_688aaec772608324b80e1902bf3ea3d5