### PR TITLE
Add temperature parameter to Grok API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 server/node_modules/
 server/package-lock.json
 server/.env
+server/dist/

--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -69,6 +69,7 @@ The final result should represent current trending topics in Mexico as reflected
           },
         ],
         model: 'grok-4',
+        temperature: 0.2,
         stream: false,
         search_parameters: { mode: 'on' },
       };
@@ -125,6 +126,7 @@ The final result should represent current trending topics in Mexico as reflected
           },
         ],
         model: 'grok-4',
+        temperature: 0.2,
         stream: false,
         search_parameters: { mode: 'on' },
       };


### PR DESCRIPTION
## Summary
- ignore server build output
- add `temperature` parameter in Grok service payloads

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_b_688bc439b8cc8324af03d972ec1c1979