### PR TITLE
Increase Grok API timeout to 10 minutes

### DIFF
--- a/server/src/grok.service.ts
+++ b/server/src/grok.service.ts
@@ -83,8 +83,8 @@ The final result should represent current trending topics in Mexico as reflected
           Accept: 'application/json',
         },
         data,
-        // Allow up to 5 minutes for the request to complete
-        timeout: 300_000,
+        // Allow up to 10 minutes for the request to complete
+        timeout: 600_000,
       };
 
       const start = Date.now();
@@ -140,7 +140,7 @@ The final result should represent current trending topics in Mexico as reflected
           Accept: 'application/json',
         },
         data,
-        timeout: 300_000,
+        timeout: 600_000,
       };
 
       const start = Date.now();


### PR DESCRIPTION
## Summary
- extend Axios request timeout in Grok service to 10 minutes

## Testing
- `npm test` (fails: missing script: "test")

------
https://chatgpt.com/codex/tasks/task_b_68912fa209508324ae4b9dad85287213